### PR TITLE
HA 구성에 필요한 HAProxy 설정 파일입니다.

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,0 +1,53 @@
+global
+	log /dev/log	local0
+	log /dev/log	local1 notice
+	chroot /var/lib/haproxy
+	stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+	stats timeout 30s
+	user haproxy
+	group haproxy
+	daemon
+
+	# Default SSL material locations
+	ca-base /etc/ssl/certs
+	crt-base /etc/ssl/private
+
+	# See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
+        ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+        ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+        ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+	log	global
+	mode	tcp
+	option	tcplog
+	option	dontlognull
+        timeout connect 60000
+        timeout client  60000
+        timeout server  60000
+	errorfile 400 /etc/haproxy/errors/400.http
+	errorfile 403 /etc/haproxy/errors/403.http
+	errorfile 408 /etc/haproxy/errors/408.http
+	errorfile 500 /etc/haproxy/errors/500.http
+	errorfile 502 /etc/haproxy/errors/502.http
+	errorfile 503 /etc/haproxy/errors/503.http
+	errorfile 504 /etc/haproxy/errors/504.http
+
+# Load Balancing for Galera Cluster
+frontend mysql_frontend
+    bind 10.0.8.100:3306
+    default_backend mysql_backend
+
+backend mysql_backend
+    option mysql-check user haproxy_check
+    server db01 10.0.8.101:3306 check
+    server db02 10.0.8.102:3306 check backup
+
+# Load Balancing for RabbitMQ
+frontend rabbitmq_frontend
+    bind 10.0.8.100:5672
+    default_backend rabbitmq_backend
+
+backend rabbitmq_backend
+    server controller1 10.0.8.101:5672 check
+    server controller2 10.0.8.102:5672 check backup


### PR DESCRIPTION
직접 작성해보았는데, 두 개의 노드에서 HAProxy를 사용하는 환경입니다.

Proxy 는 서비스들과 동일한 노드에서 동작합니다.

Pacemaker에서 VIP 설정을 먼저 해주어야 합니다.